### PR TITLE
Fix exception logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ When an `ApiProblemException` is triggered, this bundle will return the correct 
 composer require phpro/api-problem-bundle
 ```
 
-If you are not using the contrib recipes of `symfony/flex`, you'll have to manually add the bundle to your bundles file:
+If you are not using `symfony/flex`, you'll have to manually add the bundle to your bundles file:
 
 ```php
 // config/bundles.php

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.12",
         "matthiasnoback/symfony-dependency-injection-test": "^3.0",
-        "phpro/grumphp": "^0.14.1",
+        "phpro/grumphp": "^0.15.2",
         "phpunit/phpunit": "^7.2",
         "symfony/security": "^4.1"
     },

--- a/config/services.xml
+++ b/config/services.xml
@@ -9,7 +9,7 @@
         >
             <argument key="$exceptionTransformer" type="service" id="Phpro\ApiProblemBundle\Transformer\Chain" />
             <argument key="$debug" >%kernel.debug%</argument>
-            <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" />
+            <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" priority="-5" />
         </service>
         <service id="Phpro\ApiProblemBundle\Transformer\Chain" class="Phpro\ApiProblemBundle\Transformer\Chain">
             <argument type="tagged" tag="phpro.api_problem.exception_transformer" />

--- a/test/DependencyInjection/ApiProblemExtensionTest.php
+++ b/test/DependencyInjection/ApiProblemExtensionTest.php
@@ -47,6 +47,7 @@ class ApiProblemExtensionTest extends AbstractExtensionTestCase
             [
                 'event' => 'kernel.exception',
                 'method' => 'onKernelException',
+                'priority' => '-5',
             ]
         );
     }


### PR DESCRIPTION
This PR lowers the priority of the event listener to make sure the basic Symfony exception event listeners are triggered.

Fixes #3 
