### PR TITLE
Dependency update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,44 +1,33 @@
 language: php
-
-env:
-    global:
-        - DEFAULT_COMPOSER_FLAGS="--optimize-autoloader --no-interaction --no-progress"
-        - COMPOSER_FLAGS=""
-
-before_install:
-    - alias composer=composer\ --no-interaction && composer selfupdate
-
+  ​
 cache:
   directories:
-    - .composer/cache
-
+    - $HOME/.composer/cache
+  ​
+php:
+  - 7.2
+  - 7.3
+  - 7.4
+  ​
 matrix:
   fast_finish: true
-  allow_failures:
-    - php: nightly
-
-jobs:
-    include:
-        - &STANDARD_TEST_JOB
-            stage: Test
-            php: 7.2
-            install:
-                - travis_retry composer update $DEFAULT_COMPOSER_FLAGS $COMPOSER_FLAGS
-                - composer info -D | sort
-            script:
-                - vendor/bin/grumphp run
-        -
-            <<: *STANDARD_TEST_JOB
-            stage: Test
-            php: 7.2
-            env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
-        -
-            <<: *STANDARD_TEST_JOB
-            stage: Test
-            php: nightly
-            env: COMPOSER_FLAGS="--ignore-platform-reqs" PHP_CS_FIXER_IGNORE_ENV=1 PHP_CS_FIXER_FUTURE_MODE=1
-            script:
-                - vendor/bin/grumphp run
-
-    allow_failures:
-        - php: nightly
+  include:
+    - php: 7.2
+      env: SYMFONY_VERSION=4.4.*
+    - php: 7.3
+      env: SYMFONY_VERSION=4.4.*
+    - php: 7.4
+      env: SYMFONY_VERSION=4.4.*
+    - php: 7.2
+      env: SYMFONY_VERSION=5.0.*
+    - php: 7.3
+      env: SYMFONY_VERSION=5.0.*
+    - php: 7.4
+      env: SYMFONY_VERSION=5.0.*
+  ​
+before_script:
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
+  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
+  ​
+script:
+  - ./vendor/bin/grumphp run

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,33 @@
 language: php
-  ​
+
 cache:
-  directories:
-    - $HOME/.composer/cache
-  ​
+    directories:
+        - $HOME/.composer/cache
+
 php:
-  - 7.2
-  - 7.3
-  - 7.4
-  ​
+    - 7.2
+    - 7.3
+    - 7.4
+
 matrix:
-  fast_finish: true
-  include:
-    - php: 7.2
-      env: SYMFONY_VERSION=4.4.*
-    - php: 7.3
-      env: SYMFONY_VERSION=4.4.*
-    - php: 7.4
-      env: SYMFONY_VERSION=4.4.*
-    - php: 7.2
-      env: SYMFONY_VERSION=5.0.*
-    - php: 7.3
-      env: SYMFONY_VERSION=5.0.*
-    - php: 7.4
-      env: SYMFONY_VERSION=5.0.*
-  ​
+    fast_finish: true
+    include:
+        - php: 7.2
+          env: SYMFONY_VERSION=4.4.*
+        - php: 7.3
+          env: SYMFONY_VERSION=4.4.*
+        - php: 7.4
+          env: SYMFONY_VERSION=4.4.*
+        - php: 7.2
+          env: SYMFONY_VERSION=5.0.*
+        - php: 7.3
+          env: SYMFONY_VERSION=5.0.*
+        - php: 7.4
+          env: SYMFONY_VERSION=5.0.*
+
 before_script:
-  - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
-  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
-  ​
+    - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
+    - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
+
 script:
-  - ./vendor/bin/grumphp run
+    - ./vendor/bin/grumphp run

--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,16 @@
     "require": {
         "php": "^7.2",
         "phpro/api-problem": "^1.0",
-        "symfony/dependency-injection": "^4.1",
-        "symfony/event-dispatcher": "^4.1",
-        "symfony/http-kernel": "^4.1"
+        "symfony/dependency-injection": "^4.4|^5.0",
+        "symfony/event-dispatcher": "^4.4|^5.0",
+        "symfony/http-kernel": "^4.4|^5.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.12",
-        "matthiasnoback/symfony-dependency-injection-test": "^3.0",
-        "phpro/grumphp": "^0.15.2",
-        "phpunit/phpunit": "^7.2",
-        "symfony/security": "^4.1"
+        "matthiasnoback/symfony-dependency-injection-test": "^3.0|^4.0",
+        "phpro/grumphp": "^0.17.2",
+        "phpunit/phpunit": "^8.5",
+        "symfony/security-core": "^4.4|^5.0"
     },
     "config": {
         "sort-packages": true

--- a/src/EventListener/JsonApiProblemExceptionListener.php
+++ b/src/EventListener/JsonApiProblemExceptionListener.php
@@ -10,7 +10,7 @@ use Phpro\ApiProblem\Http\ExceptionApiProblem;
 use Phpro\ApiProblemBundle\Transformer\ExceptionTransformerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 
 class JsonApiProblemExceptionListener
 {
@@ -30,7 +30,7 @@ class JsonApiProblemExceptionListener
         $this->debug = $debug;
     }
 
-    public function onKernelException(GetResponseForExceptionEvent $event): void
+    public function onKernelException(ExceptionEvent $event): void
     {
         $request = $event->getRequest();
         if (
@@ -40,7 +40,8 @@ class JsonApiProblemExceptionListener
             return;
         }
 
-        $apiProblem = $this->convertExceptionToProblem($event->getException());
+        $apiProblem = $this->convertExceptionToProblem($event->getThrowable());
+
         $event->setResponse($this->generateResponse($apiProblem));
     }
 


### PR DESCRIPTION
Updated the bundle to work with symfony 4.4 to 5.0 as stated in issue #6.
Upgraded travis to test for a matrix of multiple php and symfony versions. 
Dropped support for symfony 4.1 to 4.3 due to `GetResponseForExceptionEvent` being deprecated. 

Changelog:
- Dropped support for Symfony version 4.1 and skipped to 4.4
- Add support for symfony 5.0