### PR TITLE
Compatibility with symfony 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,18 +11,18 @@
     ],
     "require": {
         "php": "^7.2",
-        "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "phpro/api-problem": "^1.0",
-        "phpro/grumphp": "^0.17.2",
-        "phpunit/phpunit": "^8.5",
         "symfony/dependency-injection": "^5.0",
         "symfony/event-dispatcher": "^5.0",
-        "symfony/http-kernel": "^5.0",
-        "symfony/security-bundle": "^5.0"
+        "symfony/http-kernel": "^5.0"
     },
     "require-dev": {
         "dg/bypass-finals": "^1.1",
-        "friendsofphp/php-cs-fixer": "^2.12"
+        "friendsofphp/php-cs-fixer": "^2.12",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.1",
+        "phpro/grumphp": "^0.17.2",
+        "phpunit/phpunit": "^8.5",
+        "symfony/security-bundle": "^5.0"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -11,17 +11,18 @@
     ],
     "require": {
         "php": "^7.2",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "phpro/api-problem": "^1.0",
-        "symfony/dependency-injection": "^4.1",
-        "symfony/event-dispatcher": "^4.1",
-        "symfony/http-kernel": "^4.1"
+        "phpro/grumphp": "^0.17.2",
+        "phpunit/phpunit": "^8.5",
+        "symfony/dependency-injection": "^5.0",
+        "symfony/event-dispatcher": "^5.0",
+        "symfony/http-kernel": "^5.0",
+        "symfony/security-bundle": "^5.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.12",
-        "matthiasnoback/symfony-dependency-injection-test": "^3.0",
-        "phpro/grumphp": "^0.15.2",
-        "phpunit/phpunit": "^7.2",
-        "symfony/security": "^4.1"
+        "dg/bypass-finals": "^1.1",
+        "friendsofphp/php-cs-fixer": "^2.12"
     },
     "config": {
         "sort-packages": true

--- a/src/EventListener/JsonApiProblemExceptionListener.php
+++ b/src/EventListener/JsonApiProblemExceptionListener.php
@@ -10,7 +10,7 @@ use Phpro\ApiProblem\Http\ExceptionApiProblem;
 use Phpro\ApiProblemBundle\Transformer\ExceptionTransformerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 
 class JsonApiProblemExceptionListener
 {
@@ -30,7 +30,7 @@ class JsonApiProblemExceptionListener
         $this->debug = $debug;
     }
 
-    public function onKernelException(GetResponseForExceptionEvent $event): void
+    public function onKernelException(ExceptionEvent $event): void
     {
         $request = $event->getRequest();
         if (
@@ -40,7 +40,7 @@ class JsonApiProblemExceptionListener
             return;
         }
 
-        $apiProblem = $this->convertExceptionToProblem($event->getException());
+        $apiProblem = $this->convertExceptionToProblem($event->getThrowable());
         $event->setResponse($this->generateResponse($apiProblem));
     }
 


### PR DESCRIPTION
Fixes #6 

GetResponseForExceptionEvent is replaced with ExceptionEvent which is a final class. Which normally cannot be mocked. Used a small library "dg/bypass-finals" which allows for mocking final classes.
