### PR TITLE
Added Exception class implementing HttpExceptionInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # Api Problem Bundle
 
 This package provides a [RFC7807](https://tools.ietf.org/html/rfc7807) Problem details exception listener for Symfony.
-Internal, this package uses the models provided by `phpro/api-problem`](https://www.github.com/phpro/api-problem).
+Internal, this package uses the models provided by [`phpro/api-problem`](https://www.github.com/phpro/api-problem).
 When an `ApiProblemException` is triggered, this bundle will return the correct response.
 
 
@@ -68,6 +68,9 @@ Body:
     "detail": "It ain't all bad ..."
 }
 ```
+
+As an alternative, use ```ApiProblemHttpException``` instead of ```ApiProblemException```, to make it possible to
+[exclude the specific status code from the log](https://symfony.com/doc/current/logging/monolog_exclude_http_codes.html)
 
 ## Adding custom exception transformations
 

--- a/src/Exception/ApiProblemHttpException.php
+++ b/src/Exception/ApiProblemHttpException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\ApiProblemBundle\Exception;
+
+use Phpro\ApiProblem\Exception\ApiProblemException;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+
+class ApiProblemHttpException extends ApiProblemException implements HttpExceptionInterface
+{
+    public function getStatusCode()
+    {
+        return $this->code > 0 ? $this->code : Response::HTTP_BAD_REQUEST;
+    }
+
+    public function getHeaders()
+    {
+        return ['Content-Type' => 'application/problem+json'];
+    }
+}

--- a/src/Exception/ApiProblemHttpException.php
+++ b/src/Exception/ApiProblemHttpException.php
@@ -4,15 +4,32 @@ declare(strict_types=1);
 
 namespace Phpro\ApiProblemBundle\Exception;
 
-use Phpro\ApiProblem\Exception\ApiProblemException;
+use Phpro\ApiProblem\ApiProblemInterface;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
-class ApiProblemHttpException extends ApiProblemException implements HttpExceptionInterface
+class ApiProblemHttpException extends HttpException
 {
+    private $apiProblem;
+
+    public function __construct(ApiProblemInterface $apiProblem)
+    {
+        $data = $apiProblem->toArray();
+        $message = $data['detail'] ?? ($data['title'] ?? '');
+        $code = (int) ($data['status'] ?? 0);
+
+        parent::__construct($code, $message);
+        $this->apiProblem = $apiProblem;
+    }
+
+    public function getApiProblem(): ApiProblemInterface
+    {
+        return $this->apiProblem;
+    }
+
     public function getStatusCode()
     {
-        return $this->code > 0 ? $this->code : Response::HTTP_BAD_REQUEST;
+        return parent::getStatusCode() > 0 ? parent::getStatusCode() : Response::HTTP_BAD_REQUEST;
     }
 
     public function getHeaders()

--- a/src/Transformer/ApiProblemExceptionTransformer.php
+++ b/src/Transformer/ApiProblemExceptionTransformer.php
@@ -6,11 +6,12 @@ namespace Phpro\ApiProblemBundle\Transformer;
 
 use Phpro\ApiProblem\ApiProblemInterface;
 use Phpro\ApiProblem\Exception\ApiProblemException;
+use Phpro\ApiProblemBundle\Exception\ApiProblemHttpException;
 
 class ApiProblemExceptionTransformer implements ExceptionTransformerInterface
 {
     /**
-     * @param ApiProblemException $exception
+     * @param ApiProblemException|ApiProblemHttpException $exception
      */
     public function transform(\Throwable $exception): ApiProblemInterface
     {
@@ -19,6 +20,6 @@ class ApiProblemExceptionTransformer implements ExceptionTransformerInterface
 
     public function accepts(\Throwable $exception): bool
     {
-        return $exception instanceof ApiProblemException;
+        return $exception instanceof ApiProblemException || $exception instanceof ApiProblemHttpException;
     }
 }

--- a/test/Exception/ApiProblemHttpExceptionTest.php
+++ b/test/Exception/ApiProblemHttpExceptionTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace PhproTest\ApiProblemBundle\Exception;
 
-use Phpro\ApiProblem\Exception\ApiProblemException;
 use Phpro\ApiProblem\Http\HttpApiProblem;
 use Phpro\ApiProblemBundle\Exception\ApiProblemHttpException;
+use Phpro\ApiProblemBundle\Transformer\ApiProblemExceptionTransformer;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
-use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class ApiProblemHttpExceptionTest extends TestCase
 {
@@ -25,11 +25,11 @@ class ApiProblemHttpExceptionTest extends TestCase
     }
 
     /** @test */
-    public function it_is_an_instance_of_ApiProblemException(): void
+    public function it_is_accepted_by_the_ApiProblemExceptionTransformer(): void
     {
-        $exception = new ApiProblemHttpException($this->apiProblem->reveal());
+        $transformer = new ApiProblemExceptionTransformer();
 
-        $this->assertInstanceOf(ApiProblemException::class, $exception);
+        $this->assertTrue($transformer->accepts(new ApiProblemHttpException($this->apiProblem->reveal())));
     }
 
     /** @test */
@@ -37,7 +37,16 @@ class ApiProblemHttpExceptionTest extends TestCase
     {
         $exception = new ApiProblemHttpException($this->apiProblem->reveal());
 
-        $this->assertInstanceOf(HttpExceptionInterface::class, $exception);
+        $this->assertInstanceOf(HttpException::class, $exception);
+    }
+
+    /** @test */
+    public function it_contains_an_api_problem(): void
+    {
+        $apiProblem = $this->apiProblem->reveal();
+
+        $exception = new ApiProblemHttpException($apiProblem);
+        $this->assertEquals($apiProblem, $exception->getApiProblem());
     }
 
     /** @test */

--- a/test/Exception/ApiProblemHttpExceptionTest.php
+++ b/test/Exception/ApiProblemHttpExceptionTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhproTest\ApiProblemBundle\Exception;
+
+use Phpro\ApiProblem\Exception\ApiProblemException;
+use Phpro\ApiProblem\Http\HttpApiProblem;
+use Phpro\ApiProblemBundle\Exception\ApiProblemHttpException;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+
+class ApiProblemHttpExceptionTest extends TestCase
+{
+    /**
+     * @var HttpApiProblem|ObjectProphecy
+     */
+    private $apiProblem;
+
+    protected function setUp(): void/* The :void return type declaration that should be here would cause a BC issue */
+    {
+        $this->apiProblem = $this->prophesize(HttpApiProblem::class);
+        $this->apiProblem->toArray()->willReturn([]);
+    }
+
+    /** @test */
+    public function it_is_an_instance_of_ApiProblemException(): void
+    {
+        $exception = new ApiProblemHttpException($this->apiProblem->reveal());
+
+        $this->assertInstanceOf(ApiProblemException::class, $exception);
+    }
+
+    /** @test */
+    public function it_is_an_instance_of_HttpException(): void
+    {
+        $exception = new ApiProblemHttpException($this->apiProblem->reveal());
+
+        $this->assertInstanceOf(HttpExceptionInterface::class, $exception);
+    }
+
+    /** @test */
+    public function it_returns_the_correct_http_headers(): void
+    {
+        $exception = new ApiProblemHttpException($this->apiProblem->reveal());
+
+        $this->assertEquals(['Content-Type' => 'application/problem+json'], $exception->getHeaders());
+    }
+
+    /** @test */
+    public function it_returns_the_correct_default_http_statuscode(): void
+    {
+        $exception = new ApiProblemHttpException($this->apiProblem->reveal());
+
+        $this->assertEquals(400, $exception->getStatusCode());
+    }
+
+    /** @test */
+    public function it_returns_the_correct_specified_http_statuscode(): void
+    {
+        $this->apiProblem->toArray()->willReturn(['status' => 401]);
+        $exception = new ApiProblemHttpException($this->apiProblem->reveal());
+
+        $this->assertEquals(401, $exception->getStatusCode());
+    }
+}


### PR DESCRIPTION
My log files are flooded with 400-exceptions due to users which are trying to implement clients for my API, not sending the correct parameters. Since the responses to their requests are self-explanatory, I don't need them in my logs. To be able to exclude them using [this configuration](https://symfony.com/doc/current/logging/monolog_exclude_http_codes.html), I've added a class extending ApiProblemException and implementing HttpExceptionInterface in my project.

Since more developers might be interested in this solution, I've decided to create a PR.

PS. Creating PR's and unit testing are both quite new for me, feedback is welcome.
