### PR TITLE
Trigger the plugin on json accept header

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ SomeController {
 }
 ```
 
-When the controller is marked as a "json" format or the request `Content-Type` is `*/json`, this bundle kicks in.
+When the controller is marked as a "json" format, the request `Content-Type` is `*/json` or the request `Accept` header first value contains json (i.e. `application/json, text/html`), this bundle kicks in.
 It will transform the exception to following response:
 
 Headers:

--- a/src/EventListener/JsonApiProblemExceptionListener.php
+++ b/src/EventListener/JsonApiProblemExceptionListener.php
@@ -34,7 +34,7 @@ class JsonApiProblemExceptionListener
     {
         $request = $event->getRequest();
         if (
-            false === mb_strpos($request->getRequestFormat(), 'json') &&
+            false === mb_strpos($request->getPreferredFormat(), 'json') &&
             false === mb_strpos((string) $request->getContentType(), 'json')
         ) {
             return;

--- a/test/EventListener/JsonApiProblemExceptionListenerTest.php
+++ b/test/EventListener/JsonApiProblemExceptionListenerTest.php
@@ -59,7 +59,7 @@ class JsonApiProblemExceptionListenerTest extends TestCase
     public function it_does_nothing_on_non_json_requests(): void
     {
         $listener = new JsonApiProblemExceptionListener($this->exceptionTransformer->reveal(), false);
-        $this->request->getRequestFormat()->willReturn('html');
+        $this->request->getPreferredFormat()->willReturn('html');
         $this->request->getContentType()->willReturn('text/html');
         $listener->onKernelException($this->event);
 
@@ -70,7 +70,7 @@ class JsonApiProblemExceptionListenerTest extends TestCase
     public function it_runs_on_json_route_formats(): void
     {
         $listener = new JsonApiProblemExceptionListener($this->exceptionTransformer->reveal(), false);
-        $this->request->getRequestFormat()->willReturn('json');
+        $this->request->getPreferredFormat()->willReturn('json');
         $this->request->getContentType()->willReturn(null);
         $listener->onKernelException($this->event);
 
@@ -81,8 +81,19 @@ class JsonApiProblemExceptionListenerTest extends TestCase
     public function it_runs_on_json_content_types(): void
     {
         $listener = new JsonApiProblemExceptionListener($this->exceptionTransformer->reveal(), false);
-        $this->request->getRequestFormat()->willReturn('html');
+        $this->request->getPreferredFormat()->willReturn('html');
         $this->request->getContentType()->willReturn('application/json');
+
+        $listener->onKernelException($this->event);
+        $this->assertApiProblemWithResponseBody(500, $this->parseDataForException());
+    }
+
+    /** @test */
+    public function it_runs_on_json_accept_header(): void
+    {
+        $listener = new JsonApiProblemExceptionListener($this->exceptionTransformer->reveal(), false);
+        $this->request->getPreferredFormat()->willReturn('json');
+        $this->request->getContentType()->willReturn('html');
 
         $listener->onKernelException($this->event);
         $this->assertApiProblemWithResponseBody(500, $this->parseDataForException());
@@ -92,7 +103,7 @@ class JsonApiProblemExceptionListenerTest extends TestCase
     public function it_parses_an_api_problem_response(): void
     {
         $listener = new JsonApiProblemExceptionListener($this->exceptionTransformer->reveal(), false);
-        $this->request->getRequestFormat()->willReturn('json');
+        $this->request->getPreferredFormat()->willReturn('json');
         $this->request->getContentType()->willReturn('application/json');
 
         $listener->onKernelException($this->event);
@@ -103,7 +114,7 @@ class JsonApiProblemExceptionListenerTest extends TestCase
     public function it_uses_an_exception_transformer(): void
     {
         $listener = new JsonApiProblemExceptionListener($this->exceptionTransformer->reveal(), false);
-        $this->request->getRequestFormat()->willReturn('json');
+        $this->request->getPreferredFormat()->willReturn('json');
         $this->request->getContentType()->willReturn('application/json');
 
         $apiProblem = $this->prophesize(ApiProblemInterface::class);
@@ -120,7 +131,7 @@ class JsonApiProblemExceptionListenerTest extends TestCase
     public function it_returns_the_status_code_from_the_api_problem(): void
     {
         $listener = new JsonApiProblemExceptionListener($this->exceptionTransformer->reveal(), false);
-        $this->request->getRequestFormat()->willReturn('json');
+        $this->request->getPreferredFormat()->willReturn('json');
         $this->request->getContentType()->willReturn('application/json');
 
         $apiProblem = $this->prophesize(ApiProblemInterface::class);
@@ -146,7 +157,7 @@ class JsonApiProblemExceptionListenerTest extends TestCase
         $this->exceptionTransformer->accepts($this->exception)->willReturn(true);
         $this->exceptionTransformer->transform($this->exception)->willReturn($apiProblem->reveal());
 
-        $this->request->getRequestFormat()->willReturn('json');
+        $this->request->getPreferredFormat()->willReturn('json');
         $this->request->getContentType()->willReturn('application/json');
 
         $listener->onKernelException($this->event);


### PR DESCRIPTION
For GET and DELETE verbs, one can not set the `Content-Type` header per definition (#10).

In this pull request, we enable the listener whenever the main `Accept` header contains `json`.

| Accept header | Triggers the listener |
|---|---|
| application/json | true |
| application/json,text/html | true |
| text/html | false |
| text/html,application/json | false |