### PR TITLE
Green CI (modern phpunit config, drop not needed ignoring requirements, phpcsfixer 3)

### DIFF
--- a/.github/workflows/grumphp.yaml
+++ b/.github/workflows/grumphp.yaml
@@ -35,12 +35,10 @@ jobs:
                   key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
                   restore-keys: ${{ runner.os }}-composer-
             - name: Install dependencies PHP
-              run: composer update --prefer-dist --no-progress --no-suggest ${{ matrix.composer-options }} --ignore-platform-reqs
+              run: composer update --prefer-dist --no-progress --no-suggest ${{ matrix.composer-options }}
             - name: Set git variables
               run: |
                   git config --global user.email "you@example.com"
                   git config --global user.name "Your Name"
             - name: Run the tests
               run: php vendor/bin/grumphp run --no-interaction
-              env:
-                  PHP_CS_FIXER_IGNORE_ENV: 1

--- a/.github/workflows/grumphp.yaml
+++ b/.github/workflows/grumphp.yaml
@@ -36,9 +36,5 @@ jobs:
                   restore-keys: ${{ runner.os }}-composer-
             - name: Install dependencies PHP
               run: composer update --prefer-dist --no-progress --no-suggest ${{ matrix.composer-options }}
-            - name: Set git variables
-              run: |
-                  git config --global user.email "you@example.com"
-                  git config --global user.name "Your Name"
             - name: Run the tests
               run: php vendor/bin/grumphp run --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,10 @@
         "symfony/security-core": "^5.3 || ^6.0"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "phpro/grumphp-shim": true
+        }
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "symfony/http-kernel": "^5.3 || ^6.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.3",
+        "friendsofphp/php-cs-fixer": "^3.4",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",
         "phpro/grumphp-shim": "^1.6.0",
         "phpspec/prophecy-phpunit": "^2.0",

--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -1,6 +1,6 @@
 grumphp:
     tasks:
-      phpcsfixer2:
+      phpcsfixer:
         config: ".php-cs-fixer.dist.php"
         config_contains_finder: true
       phpunit: ~

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+        colors="true"
+>
     <testsuites>
         <testsuite name="Unit">
             <directory>./test</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-clover" target="var/coverage.xml" />
-    </logging>
+
+  <coverage processUncoveredFiles="true">
+      <include>
+          <directory suffix=".php">src</directory>
+      </include>
+      <report>
+          <clover outputFile="var/coverage.xml"/>
+      </report>
+  </coverage>
 </phpunit>


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

Ignoring requirements was added long ago when php-cs-fixer was not compatible with PHP 8.0.
This is not the case for now.
