### PR TITLE
tagged tag is deprecated in symfony 7.2

### DIFF
--- a/config/services.xml
+++ b/config/services.xml
@@ -12,7 +12,7 @@
             <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" priority="-5" />
         </service>
         <service id="Phpro\ApiProblemBundle\Transformer\Chain" class="Phpro\ApiProblemBundle\Transformer\Chain">
-            <argument type="tagged" tag="phpro.api_problem.exception_transformer" />
+            <argument type="tagged_iterator" tag="phpro.api_problem.exception_transformer" />
         </service>
         <service id="Phpro\ApiProblemBundle\Transformer\ApiProblemExceptionTransformer" class="Phpro\ApiProblemBundle\Transformer\ApiProblemExceptionTransformer">
             <tag name="phpro.api_problem.exception_transformer" />


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

#### Summary

As of Symfony version 7.2, the `tagged` tag is deprecated.

See https://symfony.com/blog/new-in-symfony-7-2-deprecations#deprecated-the-tagged-tag
